### PR TITLE
Update documentation domain from docs.zeuz.ai to zeuz.ai

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -13,10 +13,10 @@ const config: Config = {
     trailingSlash: true,
 
     // Set the production url of your site here
-    url: "https://docs.zeuz.ai",
+    url: "https://zeuz.ai",
     // Set the /<baseUrl>/ pathname under which your site is served
     // For GitHub pages deployment, it is often '/<projectName>/'
-    baseUrl: "/",
+    baseUrl: "/docs/",
 
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.
@@ -170,7 +170,7 @@ const config: Config = {
             contextualSearch: false,
 
             // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
-            externalUrlRegex: 'docs\\.zeuz\\.ai',
+            externalUrlRegex: 'zeuz\\.ai',
 
             // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
             // replaceSearchResultPathname: {

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -84,7 +84,7 @@ function DocPageButtons() {
             subLabel: "Ask ChatGPT about this page",
             icon: "/img/icons/openai.svg",
             onClick: () => {
-                const prefix = 'https://docs.zeuz.ai';
+                const prefix = 'https://zeuz.ai';
                 const docURL = buildPathString(prefix);
                 const prompt = `Read ${docURL} and answer questions about the content`
                 const url = `https://chatgpt.com/?prompt=${prompt}`;
@@ -96,7 +96,7 @@ function DocPageButtons() {
             subLabel: "Ask Claude about this page",
             icon: "/img/icons/claude.svg",
             onClick: () => {
-                const prefix = 'https://docs.zeuz.ai';
+                const prefix = 'https://zeuz.ai';
                 const docURL = buildPathString(prefix);
                 const prompt = `Read ${docURL} and answer questions about the content`
                 const url = `https://claude.ai/new?q=${prompt}`;

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-docs.zeuz.ai
+zeuz.ai


### PR DESCRIPTION
## Summary
This PR updates the documentation site configuration to use the root domain `zeuz.ai` instead of the subdomain `docs.zeuz.ai`. The documentation will now be served under `/docs/` path on the main domain.

## Key Changes
- **docusaurus.config.ts**: Updated production URL from `https://docs.zeuz.ai` to `https://zeuz.ai` and changed baseUrl from `/` to `/docs/`
- **docusaurus.config.ts**: Updated Algolia search configuration to use the new domain pattern in `externalUrlRegex`
- **src/theme/DocItem/Content/index.tsx**: Updated hardcoded URL prefixes in ChatGPT and Claude integration buttons to use the new domain
- **static/CNAME**: Updated DNS CNAME record to point to `zeuz.ai` instead of `docs.zeuz.ai`

## Implementation Details
This change consolidates the documentation under the main domain while maintaining it in a dedicated `/docs/` subdirectory. All references to the old domain have been updated to ensure proper navigation and external tool integrations (ChatGPT, Claude) continue to work correctly with the new URL structure.

https://claude.ai/code/session_01EbVTEHueDVwaSRikAHPkeh